### PR TITLE
Allow no param types

### DIFF
--- a/lib/qb.ex
+++ b/lib/qb.ex
@@ -62,7 +62,7 @@ defmodule QB do
   defguard is_query(_q) when true # we cannot check more strictly since there is no way to check if a struct implements the `Ecto.Queryable` protocol.
   defguard is_field(x) when is_atom(x)
   defguard is_params(p) when is_map(p)
-  defguard is_param_types(p) when is_map(p) and map_size(p) > 0
+  defguard is_param_types(p) when is_map(p)
   defguard is_filter_value(_x) when true
   defguard is_filter_function(f) when is_function(f, 2)
   defguard is_filter_validator(f) when is_function(f, 1)


### PR DESCRIPTION
It is perfectly OK to use QB only for pagination and sort, and a user needs to specify only filter params. Hence, the map might be empty, and this check is too restrictive.