### PR TITLE
Tk make guards private

### DIFF
--- a/lib/query_builder.ex
+++ b/lib/query_builder.ex
@@ -4,11 +4,11 @@ defmodule QueryBuilder do
 
   ### What problem does `QueryBuilder` solve?
 
-  While writing CRUD applications we discovered we are performing the same tasks repeatedly for each search form:
-  a) validate incoming parameters
-  b) write functions that translate parameters into composable queries
-  c) compose those functions using `Enum.reduce/3`
-  d) write a conditional expression to use `Repo.all/2` or `Repo.paginate/2`
+  While writing CRUD applications, we discovered we are performing the same tasks repeatedly for each search form:
+  - validate incoming parameters
+  - write functions that translate parameters into composable queries
+  - compose those functions using `Enum.reduce/3`
+  - write a conditional expression to use `Repo.all/2` or `Repo.paginate/2`
 
   `QueryBuilder` handles validation, composition and pagination, and requires only
   specifying how to translate parameters into queries.
@@ -30,20 +30,20 @@ defmodule QueryBuilder do
     |> QueryBuilder.fetch
   ```
 
-  In above examples the library user specifies a focused function that
-  takes query and returns a new query based on the search criteria.
+  In the above examples, the library user specifies a focused function that
+  takes a query and returns a new query based on the search criteria.
   `QueryBuilder` handles parameter validation based on specified types,
-  takes the function to later use it if search parameter is specified,
-  and fetches the result with or without pagination (based on parameters).
+  takes the function to use it later if the search parameter is specified,
+  also, fetches the result with or without pagination (based on parameters).
 
-  The parameters resemble Phoenix parameters but `QueryBuilder` does not depend on Phoenix.
+  The parameters resemble Phoenix parameters, but `QueryBuilder` does not depend on Phoenix.
   The param map is anything that can be turned into an `Ecto.Changeset` for validation.
   That means `QueryBuilder` is compatible with Phoenix but can be used without it.
 
   ### Usage guidelines
 
   `QueryBuilder` is based on functions instead of modules.
-  In smaller projects it can be used directly where needed e.g. in Phoenix controllers.
+  In smaller projects, it can be used directly where needed, e.g. in Phoenix controllers.
   However, we've found it beneficial to use it in a separate module for each schema.
 
   ```
@@ -81,17 +81,17 @@ defmodule QueryBuilder do
 
   ### Comparison with other libraries
 
-  There is another library that servers similar purpose called `Ecto.Rummage`.
+  There is another library that serves similar purpose called `Ecto.Rummage`.
   `QueryBuilder` uses functions instead of modules.
-  `Ecto.Rummage` uses hooks which are modules implementing specific behaviour.
-  Hooks give more safety but we've found functions easier to use.
+  `Ecto.Rummage` uses hooks, which are modules implementing specific behaviour.
+  Hooks give more safety, but we've found functions more natural to use.
 
   `Rummage` provides default hooks that can turn some params into queries automatically.
   E.g. params that match names of fields can become `WHERE field = value`.
   We've found it confusing for queries with joins and multiple bindings,
   so `QueryBuilder` forces writing filter functions explicitly.
 
-  At present we support one way to paginate but that may be subject to change.
+  At present, we support one way to paginate, but that may be subject to change.
 
   ### Debugging
 
@@ -107,43 +107,40 @@ defmodule QueryBuilder do
 
   ### Validation
 
-  Before building queries, it is beneficial to validate that
-  incoming params are valid.
+  Before building queries, it is beneficial to validate incoming params.
   `QueryBuilder.new` requires passing param types. See `Ecto.Changeset.cast/4` for examples of schemaless changesets.
 
-  If your usecase requires additional validations,
+  If your use-case requires additional validations,
   you can pass an additional validator as the fifth parameter to `QueryBuilder.new/5`
-  `t:filter_validator/0` takes `Ecto.Changeset` right after initial cast
-  as an argument and should also return the changeset after applying validations.
+  `t:filter_validator/0` takes `Ecto.Changeset` right after initial cast as an argument and should also return the changeset after applying validations.
 
   ### Strings vs Atoms
 
   Only initial param list allows string keys.
-  `QueryBuilder` uses `Ecto.Changeset` internally so all filter and order functions
-  expect the keys to be atoms.
+  `QueryBuilder` uses `Ecto.Changeset` internally so all filter and order functions expect the keys to be atoms.
 
   ### Default params
 
   Both for filtering and ordering, it is possible to modify the initial params.
   There is a family of functions starting with `put_`, `put_default` and `clear_`.
-  All those functions expect atom keys as indicated in previous section.
+  All those functions expect atom keys as indicated in the previous section.
 
-  `put_*` functions modify the param unconditionally setting it to new value.
+  `put_*` functions modify the param unconditionally setting it to the new value.
   `put_default_*` functions set the param only if it is not present.
-  This is very handy for initial for loads.
+  It is convenient for initial page loads.
 
   ```
   UserQueryBuilder.new(%{"search" => "José"})
   |> QueryBuilder.put_default_pagination(%{page: 1})
   ```
 
-  This way, on initial load when "page" is not set, it will default to 1.
-  Later on, when the user goes to next page, the params will be:
+  This way, on initial load, when "page" is not set, it defaults to `1`.
+  Later on, when the user goes to the next page, the params will be:
   `%{"search" => "José", "page" => 2}`,
   the call to `put_default_pagination` will have no effect
   because defaults don't overwrite parameter values.
 
-  If you really want to overwrite the param, you can use `QueryBuilder.put_pagination/1`
+  If you really want to overwrite the param, you can use `QueryBuilder.put_pagination/2`
 
   ### Filtering
 
@@ -156,8 +153,8 @@ defmodule QueryBuilder do
   Functions for setting, clearing and default pagination are similar
   to those used for filtering.
   The main differences are:
-  - you don't have to specify `page` or `page_number` types in `new`
-  - you don't specify function modifying `query`
+  - you don't have to specify `page` or `page_number` types in `QueryBuilder.new/4`
+  - you don't specify function modifying `query`.
 
   ### Sorting
 

--- a/lib/query_builder.ex
+++ b/lib/query_builder.ex
@@ -222,21 +222,19 @@ defmodule QueryBuilder do
           changeset: optional_changeset()
         }
 
-  defguard is_module(m) when is_atom(m)
-  defguard is_repo(r) when is_module(r)
+  defguardp is_module(m) when is_atom(m)
+  defguardp is_repo(r) when is_module(r)
 
   # we cannot check more strictly since there is no way to check if a struct implements the `Ecto.Queryable` protocol.
-  defguard is_query(_q) when true
-  defguard is_field(x) when is_atom(x)
-  defguard is_params(p) when is_map(p)
-  defguard is_param_types(p) when is_map(p)
-  defguard is_filter_value(_x) when true
-  defguard is_filter_function(f) when is_function(f, 2)
-  defguard is_filter_validator(f) when is_function(f, 1)
-  defguard is_pagination(p) when is_nil(p) or (is_map(p) and map_size(p) == 2)
-  defguard is_page(n) when is_integer(n) and n > 0
-  defguard is_page_size(n) when is_integer(n) and n > 0
-  defguard is_sort_direction(x) when x in @sort_direction_atoms
+  defguardp is_query(_q) when true
+  defguardp is_field(x) when is_atom(x)
+  defguardp is_params(p) when is_map(p)
+  defguardp is_param_types(p) when is_map(p)
+  defguardp is_filter_function(f) when is_function(f, 2)
+  defguardp is_filter_validator(f) when is_function(f, 1)
+  defguardp is_page(n) when is_integer(n) and n > 0
+  defguardp is_page_size(n) when is_integer(n) and n > 0
+  defguardp is_sort_direction(x) when x in @sort_direction_atoms
 
   @enforce_keys [:repo, :base_query, :params, :param_types]
   defstruct repo: nil,


### PR DESCRIPTION
I believe we meant the guards for internal use.
If that is not the case - close the PR without merging.

Unused private guards give warnings, so I needed to delete two.