### PR TITLE
Apply a default sorting function for a sort field

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  line_length: 89
 ]

--- a/lib/query_builder.ex
+++ b/lib/query_builder.ex
@@ -200,7 +200,12 @@ defmodule QueryBuilder do
   @type pagination :: %{page: page(), page_size: page_size()}
   @type optional_pagination :: pagination() | %{}
   @type sort_direction ::
-          :asc | :asc_nulls_first | :asc_nulls_last | :desc | :desc_nulls_first | :desc_nulls_last
+          :asc
+          | :asc_nulls_first
+          | :asc_nulls_last
+          | :desc
+          | :desc_nulls_first
+          | :desc_nulls_last
   @type sort_clause :: {field(), sort_direction()}
   @type sort :: [sort_clause()]
   @type sort_fun :: (query(), sort_direction() -> query())
@@ -285,7 +290,9 @@ defmodule QueryBuilder do
   end
 
   @spec cast_filters(t()) :: t()
-  defp cast_filters(%__MODULE__{changeset: %Changeset{valid?: true} = cs} = query_builder) do
+  defp cast_filters(
+         %__MODULE__{changeset: %Changeset{valid?: true} = cs} = query_builder
+       ) do
     filters =
       cs.changes
       |> Map.drop(@special_parameters)
@@ -298,7 +305,9 @@ defmodule QueryBuilder do
   end
 
   @spec cast_pagination(t()) :: t()
-  defp cast_pagination(%__MODULE__{changeset: %Changeset{valid?: true} = cs} = query_builder) do
+  defp cast_pagination(
+         %__MODULE__{changeset: %Changeset{valid?: true} = cs} = query_builder
+       ) do
     pagination =
       cs.changes
       |> Map.take(@pagination_keys)
@@ -312,7 +321,8 @@ defmodule QueryBuilder do
 
   @spec cast_sort(t()) :: t()
   defp cast_sort(
-         %__MODULE__{changeset: %Changeset{} = cs, params: %{"sort" => sort}} = query_builder
+         %__MODULE__{changeset: %Changeset{} = cs, params: %{"sort" => sort}} =
+           query_builder
        ) do
     modified_cs = Sort.cast_sort_clauses(cs, sort)
 
@@ -443,7 +453,10 @@ defmodule QueryBuilder do
   end
 
   @spec put_default_filters(t(), params()) :: t()
-  def put_default_filters(%__MODULE__{filters: filters} = query_builder, %{} = param_filters) do
+  def put_default_filters(
+        %__MODULE__{filters: filters} = query_builder,
+        %{} = param_filters
+      ) do
     modified_filters = Map.merge(param_filters, filters)
     put_params(query_builder, modified_filters)
   end
@@ -461,7 +474,10 @@ defmodule QueryBuilder do
         filter_fun
       )
       when is_field(field) and is_filter_function(filter_fun) do
-    %__MODULE__{query_builder | filter_functions: Map.put(filter_functions, field, filter_fun)}
+    %__MODULE__{
+      query_builder
+      | filter_functions: Map.put(filter_functions, field, filter_fun)
+    }
   end
 
   @spec query(t()) :: query()
@@ -514,8 +530,10 @@ defmodule QueryBuilder do
   end
 
   def fetch(
-        %__MODULE__{repo: repo, pagination: %{page: page, page_size: page_size} = pagination} =
-          query_builder
+        %__MODULE__{
+          repo: repo,
+          pagination: %{page: page, page_size: page_size} = pagination
+        } = query_builder
       )
       when is_page(page) and is_page_size(page_size) do
     query_builder

--- a/lib/query_builder.ex
+++ b/lib/query_builder.ex
@@ -1,4 +1,5 @@
 defmodule QueryBuilder do
+  alias Ecto.Changeset
   alias QueryBuilder.Sort
   import Ecto.Query, only: [from: 2]
   import Sort, only: [is_sort_direction: 1, is_sort_function: 1]
@@ -41,7 +42,7 @@ defmodule QueryBuilder do
   also, fetches the result with or without pagination (based on parameters).
 
   The parameters resemble Phoenix parameters, but `QueryBuilder` does not depend on Phoenix.
-  The param map is anything that can be turned into an `Ecto.Changeset` for validation.
+  The param map is anything that can be turned into an `Changeset` for validation.
   That means `QueryBuilder` is compatible with Phoenix but can be used without it.
 
   ### Usage guidelines
@@ -112,16 +113,16 @@ defmodule QueryBuilder do
   ### Validation
 
   Before building queries, it is beneficial to validate incoming params.
-  `QueryBuilder.new` requires passing param types. See `Ecto.Changeset.cast/4` for examples of schemaless changesets.
+  `QueryBuilder.new` requires passing param types. See `Changeset.cast/4` for examples of schemaless changesets.
 
   If your use-case requires additional validations,
   you can pass an additional validator as the fifth parameter to `QueryBuilder.new/5`
-  `t:filter_validator/0` takes `Ecto.Changeset` right after initial cast as an argument and should also return the changeset after applying validations.
+  `t:filter_validator/0` takes `Changeset` right after initial cast as an argument and should also return the changeset after applying validations.
 
   ### Strings vs Atoms
 
   Only initial param list allows string keys.
-  `QueryBuilder` uses `Ecto.Changeset` internally so all filter and order functions expect the keys to be atoms.
+  `QueryBuilder` uses `Changeset` internally so all filter and order functions expect the keys to be atoms.
 
   ### Default params
 
@@ -191,7 +192,7 @@ defmodule QueryBuilder do
   @type param_types :: %{required(field()) => param_type()}
   @type filter_value :: term()
   @type filter_fun :: (query(), term() -> query())
-  @type filter_validator :: (Ecto.Changeset.t() -> Ecto.Changeset.t())
+  @type filter_validator :: (Changeset.t() -> Changeset.t())
   @type filters :: %{required(field()) => filter_value()}
   @type filter_functions :: %{required(field()) => filter_fun()}
   @type page :: pos_integer()
@@ -204,7 +205,7 @@ defmodule QueryBuilder do
   @type sort :: [sort_clause()]
   @type sort_fun :: (query(), sort_direction() -> query())
   # really ugly but we cannot specify a map with string keys as we can with the atom keys.
-  @type optional_changeset :: Ecto.Changeset.t() | nil
+  @type optional_changeset :: Changeset.t() | nil
   @type t :: %__MODULE__{
           repo: repo(),
           base_query: query(),
@@ -265,7 +266,7 @@ defmodule QueryBuilder do
        when is_params(params) and is_param_types(param_types) and
               is_filter_validator(filter_validator) do
     modified_cs =
-      Ecto.Changeset.cast(
+      Changeset.cast(
         {%{}, param_types},
         params,
         Map.keys(param_types)
@@ -276,7 +277,7 @@ defmodule QueryBuilder do
       query_builder
       | params: params,
         changeset: modified_cs,
-        filters: Ecto.Changeset.apply_changes(modified_cs)
+        filters: Changeset.apply_changes(modified_cs)
     }
     |> cast_filters()
     |> cast_pagination()
@@ -284,7 +285,7 @@ defmodule QueryBuilder do
   end
 
   @spec cast_filters(t()) :: t()
-  defp cast_filters(%__MODULE__{changeset: %Ecto.Changeset{valid?: true} = cs} = query_builder) do
+  defp cast_filters(%__MODULE__{changeset: %Changeset{valid?: true} = cs} = query_builder) do
     filters =
       cs.changes
       |> Map.drop(@special_parameters)
@@ -292,12 +293,12 @@ defmodule QueryBuilder do
     %__MODULE__{query_builder | filters: filters}
   end
 
-  defp cast_filters(%__MODULE__{changeset: %Ecto.Changeset{valid?: false}} = query_builder) do
+  defp cast_filters(%__MODULE__{changeset: %Changeset{valid?: false}} = query_builder) do
     query_builder
   end
 
   @spec cast_pagination(t()) :: t()
-  defp cast_pagination(%__MODULE__{changeset: %Ecto.Changeset{valid?: true} = cs} = query_builder) do
+  defp cast_pagination(%__MODULE__{changeset: %Changeset{valid?: true} = cs} = query_builder) do
     pagination =
       cs.changes
       |> Map.take(@pagination_keys)
@@ -305,33 +306,33 @@ defmodule QueryBuilder do
     %__MODULE__{query_builder | pagination: pagination}
   end
 
-  defp cast_pagination(%__MODULE__{changeset: %Ecto.Changeset{valid?: false}} = query_builder) do
+  defp cast_pagination(%__MODULE__{changeset: %Changeset{valid?: false}} = query_builder) do
     query_builder
   end
 
   @spec cast_sort(t()) :: t()
   defp cast_sort(
-         %__MODULE__{changeset: %Ecto.Changeset{} = cs, params: %{"sort" => sort}} = query_builder
+         %__MODULE__{changeset: %Changeset{} = cs, params: %{"sort" => sort}} = query_builder
        ) do
     modified_cs = Sort.cast_sort_clauses(cs, sort)
 
     %__MODULE__{
       query_builder
       | changeset: modified_cs,
-        sort: Ecto.Changeset.get_change(modified_cs, @sort_key) || []
+        sort: Changeset.get_change(modified_cs, @sort_key) || []
     }
   end
 
   defp cast_sort(%__MODULE__{} = query_builder), do: query_builder
 
-  @spec validate_sort(Ecto.Changeset.t(), term()) :: Ecto.Changeset.t()
-  defp validate_sort(%Ecto.Changeset{} = cs, sort)
+  @spec validate_sort(Changeset.t(), term()) :: Changeset.t()
+  defp validate_sort(%Changeset{} = cs, sort)
        when is_list(sort) do
     Sort.validate_sort_clauses(cs, sort)
   end
 
-  defp validate_sort(%Ecto.Changeset{} = cs, _) do
-    Ecto.Changeset.add_error(
+  defp validate_sort(%Changeset{} = cs, _) do
+    Changeset.add_error(
       cs,
       @sort_key,
       "must be a list of sort clauses",
@@ -340,8 +341,8 @@ defmodule QueryBuilder do
   end
 
   @spec put_sort(t(), term()) :: t()
-  def put_sort(%__MODULE__{changeset: %Ecto.Changeset{} = cs} = query_builder, sort) do
-    original_cs = %Ecto.Changeset{cs | errors: List.keydelete(cs.errors, @sort_key, 0)}
+  def put_sort(%__MODULE__{changeset: %Changeset{} = cs} = query_builder, sort) do
+    original_cs = %Changeset{cs | errors: List.keydelete(cs.errors, @sort_key, 0)}
     errors_before = length(original_cs.errors)
     modified_cs = validate_sort(original_cs, sort)
     errors_after = length(modified_cs.errors)
@@ -350,7 +351,7 @@ defmodule QueryBuilder do
       %__MODULE__{
         query_builder
         | sort: sort,
-          changeset: Ecto.Changeset.put_change(modified_cs, @sort_key, sort)
+          changeset: Changeset.put_change(modified_cs, @sort_key, sort)
       }
     else
       %__MODULE__{query_builder | changeset: modified_cs}
@@ -402,27 +403,27 @@ defmodule QueryBuilder do
 
   @spec put_pagination(t(), optional_pagination()) :: t()
   def put_pagination(
-        %__MODULE__{changeset: %Ecto.Changeset{} = cs} = query_builder,
+        %__MODULE__{changeset: %Changeset{} = cs} = query_builder,
         empty_pagination
       )
       when empty_pagination == %{} do
     modified_cs =
       cs
-      |> Ecto.Changeset.delete_change(@page_key)
-      |> Ecto.Changeset.delete_change(@page_size_key)
+      |> Changeset.delete_change(@page_key)
+      |> Changeset.delete_change(@page_size_key)
 
     %__MODULE__{query_builder | pagination: %{}, changeset: modified_cs}
   end
 
-  def put_pagination(%__MODULE__{changeset: %Ecto.Changeset{} = cs} = query_builder, %{
+  def put_pagination(%__MODULE__{changeset: %Changeset{} = cs} = query_builder, %{
         page: page,
         page_size: page_size
       })
       when is_page(page) and is_page_size(page_size) do
     modified_cs =
       cs
-      |> Ecto.Changeset.put_change(@page_key, page)
-      |> Ecto.Changeset.put_change(@page_size_key, page_size)
+      |> Changeset.put_change(@page_key, page)
+      |> Changeset.put_change(@page_size_key, page_size)
 
     %__MODULE__{
       query_builder
@@ -522,16 +523,16 @@ defmodule QueryBuilder do
     |> repo.paginate(pagination)
   end
 
-  def has_errors?(%__MODULE__{changeset: %Ecto.Changeset{} = cs}) do
+  def has_errors?(%__MODULE__{changeset: %Changeset{} = cs}) do
     cs.valid? and cs.errors === []
   end
 
-  def has_error?(%__MODULE__{changeset: %Ecto.Changeset{errors: errors}}, field)
+  def has_error?(%__MODULE__{changeset: %Changeset{errors: errors}}, field)
       when is_field(field) do
     Keyword.has_key?(errors, field)
   end
 
-  def get_error(%__MODULE__{changeset: %Ecto.Changeset{errors: errors}}, field)
+  def get_error(%__MODULE__{changeset: %Changeset{errors: errors}}, field)
       when is_field(field) do
     Keyword.get(errors, field)
   end

--- a/lib/query_builder/sort.ex
+++ b/lib/query_builder/sort.ex
@@ -39,7 +39,9 @@ defmodule QueryBuilder.Sort do
   end
 
   def cast_sort_clauses(%Ecto.Changeset{} = cs, _) do
-    Ecto.Changeset.add_error(cs, @sort_key, "must be a list of sort clauses", clauses: :not_a_list)
+    Ecto.Changeset.add_error(cs, @sort_key, "must be a list of sort clauses",
+      clauses: :not_a_list
+    )
   end
 
   defp all_fields_are_atoms(sort) do

--- a/test/query_builder_test.exs
+++ b/test/query_builder_test.exs
@@ -2,6 +2,7 @@ defmodule QueryBuilderTest do
   use ExUnit.Case
   doctest QueryBuilder
 
+  alias Ecto.Changeset
   alias QueryBuilder.{Repo, User}
 
   import Ecto.Query
@@ -80,7 +81,7 @@ defmodule QueryBuilderTest do
 
   defp verify_filter_params(changeset) do
     changeset
-    |> Ecto.Changeset.validate_length(:search, min: 2)
+    |> Changeset.validate_length(:search, min: 2)
   end
 
   test "create with valid params and valid types, including pagination and sorting" do
@@ -91,7 +92,7 @@ defmodule QueryBuilderTest do
 
     assert Repo === query_builder.repo
     assert User === query_builder.base_query
-    assert match?(%Ecto.Changeset{valid?: true, errors: []}, query_builder.changeset)
+    assert match?(%Changeset{valid?: true, errors: []}, query_builder.changeset)
     assert @valid_params === query_builder.params
     assert @valid_param_types === Map.take(query_builder.param_types, @valid_param_keys)
 
@@ -101,8 +102,8 @@ defmodule QueryBuilderTest do
            )
 
     assert %{search: "clubcollect", adult: true} === query_builder.filters
-    assert "clubcollect" === Ecto.Changeset.get_change(query_builder.changeset, :search)
-    assert true === Ecto.Changeset.get_change(query_builder.changeset, :adult)
+    assert "clubcollect" === Changeset.get_change(query_builder.changeset, :search)
+    assert true === Changeset.get_change(query_builder.changeset, :adult)
     assert %{page: 1, page_size: 1} === query_builder.pagination
     assert [desc: :birthdate, asc: :inserted_at] === query_builder.sort
 
@@ -184,8 +185,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_pagination(%{page: 3, page_size: 20})
 
     assert %{page: 3, page_size: 20} === query_builder.pagination
-    assert 3 === Ecto.Changeset.get_change(query_builder.changeset, :page)
-    assert 20 === Ecto.Changeset.get_change(query_builder.changeset, :page_size)
+    assert 3 === Changeset.get_change(query_builder.changeset, :page)
+    assert 20 === Changeset.get_change(query_builder.changeset, :page_size)
   end
 
   test "default pagination is correct when no user pagination is supplied" do
@@ -196,8 +197,8 @@ defmodule QueryBuilderTest do
     dp = @default_pagination
 
     assert dp == query_builder.pagination
-    assert dp.page === Ecto.Changeset.get_change(query_builder.changeset, :page)
-    assert dp.page_size === Ecto.Changeset.get_change(query_builder.changeset, :page_size)
+    assert dp.page === Changeset.get_change(query_builder.changeset, :page)
+    assert dp.page_size === Changeset.get_change(query_builder.changeset, :page_size)
   end
 
   test "default pagination is not applied when a user pagination is supplied" do
@@ -207,8 +208,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_default_pagination(@default_pagination)
 
     assert %{page: 3, page_size: 20} === query_builder.pagination
-    assert 3 === Ecto.Changeset.get_change(query_builder.changeset, :page)
-    assert 20 === Ecto.Changeset.get_change(query_builder.changeset, :page_size)
+    assert 3 === Changeset.get_change(query_builder.changeset, :page)
+    assert 20 === Changeset.get_change(query_builder.changeset, :page_size)
   end
 
   test "explicit changing of pagination overwrites initial parameters" do
@@ -217,8 +218,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_pagination(%{page: 3, page_size: 20})
 
     assert %{page: 3, page_size: 20} === query_builder.pagination
-    assert 3 === Ecto.Changeset.get_change(query_builder.changeset, :page)
-    assert 20 === Ecto.Changeset.get_change(query_builder.changeset, :page_size)
+    assert 3 === Changeset.get_change(query_builder.changeset, :page)
+    assert 20 === Changeset.get_change(query_builder.changeset, :page_size)
   end
 
   test "default filters are correct when no user filters are supplied" do
@@ -227,8 +228,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_default_filters(%{search: "huh?", adult: false})
 
     assert %{search: "huh?", adult: false} === query_builder.filters
-    assert "huh?" === Ecto.Changeset.get_change(query_builder.changeset, :search)
-    assert false === Ecto.Changeset.get_change(query_builder.changeset, :adult)
+    assert "huh?" === Changeset.get_change(query_builder.changeset, :search)
+    assert false === Changeset.get_change(query_builder.changeset, :adult)
   end
 
   test "default filters are not applied when user filters are supplied" do
@@ -237,8 +238,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_default_filters(%{search: "huh?", adult: false})
 
     assert %{search: "clubcollect", adult: true} === query_builder.filters
-    assert "clubcollect" === Ecto.Changeset.get_change(query_builder.changeset, :search)
-    assert true === Ecto.Changeset.get_change(query_builder.changeset, :adult)
+    assert "clubcollect" === Changeset.get_change(query_builder.changeset, :search)
+    assert true === Changeset.get_change(query_builder.changeset, :adult)
   end
 
   test "explicitly set filters override defaults" do
@@ -248,8 +249,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_filters(%{search: "custom", adult: true})
 
     assert %{search: "custom", adult: true} === query_builder.filters
-    assert "custom" === Ecto.Changeset.get_change(query_builder.changeset, :search)
-    assert true === Ecto.Changeset.get_change(query_builder.changeset, :adult)
+    assert "custom" === Changeset.get_change(query_builder.changeset, :search)
+    assert true === Changeset.get_change(query_builder.changeset, :adult)
   end
 
   test "explicitly set filters override initial parameters" do
@@ -258,8 +259,8 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_filters(%{search: "huh?", adult: false})
 
     assert %{search: "huh?", adult: false} === query_builder.filters
-    assert "huh?" === Ecto.Changeset.get_change(query_builder.changeset, :search)
-    assert false === Ecto.Changeset.get_change(query_builder.changeset, :adult)
+    assert "huh?" === Changeset.get_change(query_builder.changeset, :search)
+    assert false === Changeset.get_change(query_builder.changeset, :adult)
   end
 
   test "passing sort clauses that are not a list is reported" do
@@ -356,7 +357,7 @@ defmodule QueryBuilderTest do
       |> QueryBuilder.put_sort(asc: :id)
 
     assert [asc: :id] === query_builder.sort
-    assert [asc: :id] === Ecto.Changeset.get_change(query_builder.changeset, :sort)
+    assert [asc: :id] === Changeset.get_change(query_builder.changeset, :sort)
   end
 
   test "adding sort field works" do
@@ -367,7 +368,7 @@ defmodule QueryBuilderTest do
     assert [desc: :birthdate, asc: :inserted_at, desc: :id] === query_builder.sort
 
     assert [desc: :birthdate, asc: :inserted_at, desc: :id] ===
-             Ecto.Changeset.get_change(query_builder.changeset, :sort)
+             Changeset.get_change(query_builder.changeset, :sort)
   end
 
   test "default sort does not override parameter sort if they pertain to the same fields" do
@@ -378,7 +379,7 @@ defmodule QueryBuilderTest do
     assert [desc: :birthdate, asc: :inserted_at] === query_builder.sort
 
     assert [desc: :birthdate, asc: :inserted_at] ===
-             Ecto.Changeset.get_change(query_builder.changeset, :sort)
+             Changeset.get_change(query_builder.changeset, :sort)
   end
 
   test "default sort does not override parameter sort even if they pertain to different fields" do
@@ -389,7 +390,7 @@ defmodule QueryBuilderTest do
     assert [desc: :birthdate, asc: :inserted_at] === query_builder.sort
 
     assert [desc: :birthdate, asc: :inserted_at] ===
-             Ecto.Changeset.get_change(query_builder.changeset, :sort)
+             Changeset.get_change(query_builder.changeset, :sort)
   end
 
   test "default sort gets merged with parameter sort if they pertain to different fields" do
@@ -401,7 +402,7 @@ defmodule QueryBuilderTest do
              query_builder.sort
 
     assert [desc: :birthdate, asc: :inserted_at, asc: :id, desc: :updated_at] ===
-             Ecto.Changeset.get_change(query_builder.changeset, :sort)
+             Changeset.get_change(query_builder.changeset, :sort)
   end
 
   test "default sort gets unconditionally applied if parameters contained no sort" do
@@ -412,7 +413,7 @@ defmodule QueryBuilderTest do
     assert [asc: :id, desc: :updated_at] === query_builder.sort
 
     assert [asc: :id, desc: :updated_at] ===
-             Ecto.Changeset.get_change(query_builder.changeset, :sort)
+             Changeset.get_change(query_builder.changeset, :sort)
   end
 
   test "reports errors from custom validations" do

--- a/test/query_builder_test.exs
+++ b/test/query_builder_test.exs
@@ -88,8 +88,6 @@ defmodule QueryBuilderTest do
       QueryBuilder.new(Repo, User, @valid_params, @valid_param_types)
       |> QueryBuilder.put_filter_function(:search, &filter_users_by_search/2)
       |> QueryBuilder.put_filter_function(:adult, &filter_users_by_adult/2)
-      |> QueryBuilder.put_sort_function(:birthdate, &sort_by_birthdate/2)
-      |> QueryBuilder.put_sort_function(:inserted_at, &sort_by_inserted_at/2)
 
     assert Repo === query_builder.repo
     assert User === query_builder.base_query
@@ -146,8 +144,6 @@ defmodule QueryBuilderTest do
       QueryBuilder.new(Repo, User, @valid_params, @valid_param_types)
       |> QueryBuilder.put_filter_function(:search, &filter_users_by_search/2)
       |> QueryBuilder.put_filter_function(:adult, &filter_users_by_adult/2)
-      |> QueryBuilder.put_sort_function(:birthdate, &sort_by_birthdate/2)
-      |> QueryBuilder.put_sort_function(:inserted_at, &sort_by_inserted_at/2)
       |> QueryBuilder.query()
       |> Repo.all()
 
@@ -166,8 +162,6 @@ defmodule QueryBuilderTest do
       )
       |> QueryBuilder.put_filter_function(:search, &filter_users_by_search/2)
       |> QueryBuilder.put_filter_function(:adult, &filter_users_by_adult/2)
-      |> QueryBuilder.put_sort_function(:birthdate, &sort_by_birthdate/2)
-      |> QueryBuilder.put_sort_function(:inserted_at, &sort_by_inserted_at/2)
       |> QueryBuilder.fetch()
 
     assert fetched_users == [expected_user]
@@ -178,8 +172,6 @@ defmodule QueryBuilderTest do
       QueryBuilder.new(Repo, User, @valid_params, @valid_param_types)
       |> QueryBuilder.put_filter_function(:search, &filter_users_by_search/2)
       |> QueryBuilder.put_filter_function(:adult, &filter_users_by_adult/2)
-      |> QueryBuilder.put_sort_function(:birthdate, &sort_by_birthdate/2)
-      |> QueryBuilder.put_sort_function(:inserted_at, &sort_by_inserted_at/2)
       |> QueryBuilder.fetch()
 
     assert match?(%Scrivener.Page{}, fetched_users)


### PR DESCRIPTION
...if it is supplied in the sorting parameters but no sorting function is supplied. This is done so as to prevent copy-pasted bloat functions with 99% the same content.

I found myself writing functions like these while I was attempting to use the library:

```elixir
  defp sort_by_id(query, sort_direction) do
    from(u in query, order_by: [{^sort_direction, u.id}])
  end

  defp sort_by_inserted_at(query, sort_direction) do
    from(u in query, order_by: [{^sort_direction, u.inserted_at}])
  end
```

This is further exacerbated by the need to pipe calls like these so the functions are at all used:

```elixir
    |> QueryBuilder.put_sort_function(:id, &sort_by_id/2)
    |> QueryBuilder.put_sort_function(:inserted_at, &sort_by_inserted_at/2)
```

To me, this is a lot of boilerplate. IMO if the user supplies sorting field(s) they have the right to expect a default sorting action, namely the direction they chose (it is **not** ignored, it is used by the default function, check the PR code for details) is applied to the field in question.

This PR completely eliminates the need for both code snippets above. All that's needed for this new behaviour to work is the user to supply a sort field and direction in the HTTP-like parameters passed to the `QueryBuilder`, _without_ calling `put_sort_function/2`.

---

Tasks:
- [x] Implement the default sorting function feature
- [x] Add tests, possibly edit older tests as well
- [x] Alias `Ecto.Changeset` (got irritated I was using its full name everywhere)